### PR TITLE
Fix fingerprint removing when disabling screen lock.

### DIFF
--- a/fingerprint/Fpc1020Sensor.cpp
+++ b/fingerprint/Fpc1020Sensor.cpp
@@ -183,6 +183,7 @@ int Fpc1020Sensor::removeId(EnrolledFingerprint& fp)
 
     if (ret == 0) {
         mFpMetadata.removeItem(fp.fid);
+        mRemoveCb(&fp, mCbData);
         if (mFpMetadata.isEmpty()) {
             mAuthenticatorId = 0;
         }
@@ -385,6 +386,11 @@ int Fpc1020Sensor::clearEnrolledFingerprints()
         ret = sendCommand(CLIENT_CMD_REMOVE_ID);
         if (ret) {
             ALOGE("Removing fingerprint ID %d failed (%d)", id, ret);
+        } else {
+            ssize_t index = mFpMetadata.indexOfKey(id);
+            uint32_t gid = index >= 0 ? mFpMetadata.valueAt(index).gid : 0;
+            EnrolledFingerprint fp(id, gid);
+            mRemoveCb(&fp, mCbData);
         }
     }
 

--- a/fingerprint/Fpc1020Sensor.h
+++ b/fingerprint/Fpc1020Sensor.h
@@ -37,16 +37,19 @@ class Fpc1020Sensor {
         typedef void (*AcquiredCb) (void *data);
         typedef void (*EnrollmentProgressCb) (const EnrolledFingerprint *fp, int stepsRemaining, void *data);
         typedef void (*AuthenticateResultCb) (const EnrolledFingerprint *fp, uint32_t userId, void *data);
+        typedef void (*RemoveCb) (const EnrolledFingerprint *fp, void *data);
         typedef void (*ErrorCb) (int result, void *data);
 
         Fpc1020Sensor(AcquiredCb acquiredCb, EnrollmentProgressCb enrollmentCb,
-                AuthenticateResultCb authenticateCb, ErrorCb errorCb, void *cbData) :
+                AuthenticateResultCb authenticateCb, RemoveCb removeCb,
+                ErrorCb errorCb, void *cbData) :
             mQseecom("fingerprints", 512),
             mFpcFd(-1),
             mCancelledDueToTimeout(false),
             mAcquiredCb(acquiredCb),
             mEnrollmentCb(enrollmentCb),
             mAuthenticateCb(authenticateCb),
+            mRemoveCb(removeCb),
             mErrorCb(errorCb),
             mCbData(cbData),
             mAuthenticatorId(0)
@@ -156,6 +159,7 @@ class Fpc1020Sensor {
         AcquiredCb mAcquiredCb;
         EnrollmentProgressCb mEnrollmentCb;
         AuthenticateResultCb mAuthenticateCb;
+        RemoveCb mRemoveCb;
         ErrorCb mErrorCb;
         void * mCbData;
 


### PR DESCRIPTION
When called with fid=0 (which means 'clear all fingerprints') we are
supposed to send out a notification for each removed fingerprint, not
only one notification for all combined.

Change-Id: I1494937c22324e0b263237aa41b5f897fd480813