### PR TITLE
Fix SPEAKER_AND_HEADPHONES device output.

### DIFF
--- a/audio/audio_platform_info.xml
+++ b/audio/audio_platform_info.xml
@@ -39,7 +39,7 @@
         <device name="SND_DEVICE_OUT_VOICE_HEADPHONES" backend="headphones" />
         <device name="SND_DEVICE_OUT_SPEAKER" backend="speaker" />
         <device name="SND_DEVICE_OUT_VOICE_SPEAKER" backend="speaker" />
-        <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" backend="speaker-and-headphones" />
+        <device name="SND_DEVICE_OUT_SPEAKER_AND_HEADPHONES" backend="headphones" />
     </backend_names>
 
     <pcm_ids>

--- a/audio/mixer_paths_mtp.xml
+++ b/audio/mixer_paths_mtp.xml
@@ -203,11 +203,6 @@
         <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia1" value="1" />
     </path>
 
-    <path name="deep-buffer-playback speaker-and-headphones">
-        <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia1" value="1" />
-        <ctl name="SEC_MI2S_RX Audio Mixer MultiMedia1" value="1" />
-    </path>
-
     <path name="deep-buffer-playback headphones">
         <ctl name="SEC_MI2S_RX Audio Mixer MultiMedia1" value="1" />
     </path>
@@ -246,11 +241,6 @@
         <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia5" value="1" />
     </path>
 
-    <path name="low-latency-playback speaker-and-headphones">
-        <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia5" value="1" />
-        <ctl name="SEC_MI2S_RX Audio Mixer MultiMedia5" value="1" />
-    </path>
-
     <path name="low-latency-playback headphones">
         <ctl name="SEC_MI2S_RX Audio Mixer MultiMedia5" value="1" />
     </path>
@@ -287,11 +277,6 @@
 
     <path name="compress-offload-playback speaker">
         <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia4" value="1" />
-    </path>
-
-    <path name="compress-offload-playback speaker-and-headphones">
-        <ctl name="QUAT_MI2S_RX Audio Mixer MultiMedia4" value="1" />
-        <ctl name="SEC_MI2S_RX Audio Mixer MultiMedia4" value="1" />
     </path>
 
     <path name="compress-offload-playback headphones">


### PR DESCRIPTION
We can't output over multiple I2S interfaces at the same time (as doing
so makes the DSP very unhappy), which means we can't simultaneously
output over both speaker and headphones. Use the sanest choice left and
play over headphones only, which matches ColorOS behaviour.

Change-Id: Ibccaa1b6bd5d94b225406adddabeb2d5c97b6c2e